### PR TITLE
Use docs.libuv.org

### DIFF
--- a/exercises/02_idle/problem.md
+++ b/exercises/02_idle/problem.md
@@ -11,10 +11,10 @@ Instead you are to fill in the 4 steps outlined in the comments.
 You may find the following links useful:
 
 **initializing and starting an idle handler**
-- https://github.com/thlorenz/libuv-dox/blob/master/methods.md#idle
+- http://docs.libuv.org/en/latest/idle.html
 
 **creating and running the event loop**
-- https://github.com/thlorenz/libuv-dox/blob/master/methods.md#loop
+- http://docs.libuv.org/en/latest/loop.html
 
 ### Hints
 

--- a/exercises/02_idle/problem.md
+++ b/exercises/02_idle/problem.md
@@ -16,9 +16,7 @@ You may find the following links useful:
 **creating and running the event loop**
 - http://docs.libuv.org/en/latest/loop.html
 
-### Hints
+### Hint
 
 Create a `default` loop and Use the `UV_RUN_DEFAULT` mode when running it.
 
-This example may also help you if you get stuck (ignore the fact that we are creating a `new` loop in it).
-- https://github.com/thlorenz/libuv-dox/blob/master/methods.md#examples

--- a/exercises/03_fs_readsync/problem.md
+++ b/exercises/03_fs_readsync/problem.md
@@ -15,15 +15,8 @@ However this is **not** the best solution and therefore we will improve on it in
 
 You should keep the following resources open and refer to them repeatedly:
 
-- [official libuv documentation](http://libuv.readthedocs.org/en/latest/index.html) *you should make use of the searchbox*
-- [the unoffical libuv dox](https://github.com/thlorenz/libuv-dox) 
-
-**libuv-dox** was created manually, structured differently than the official docs site and is preferred in some
-cases. It is organized into three main sections:
-
-  - [methods](https://github.com/thlorenz/libuv-dox/blob/master/methods.md)
-  - [types](https://github.com/thlorenz/libuv-dox/blob/master/types.md)
-  - [callbacks](https://github.com/thlorenz/libuv-dox/blob/master/callbacks.md)
+- [official libuv documentation](http://docs.libuv.org/en/latest/index.html) *you should make use of the "Quick Search" box*
+- [Unoffical libuv dox examples](https://github.com/thlorenz/libuv-dox/tree/master/examples) 
 
 From now on each exercise will have a **Resource** section towards the bottom of the instruction which guide you to the libuv
 API you will need.
@@ -62,10 +55,10 @@ After you filled in the missing pieces, you shouldn't get any warnings related t
 
 ## Resources
 
-- [`uv_fs_open`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_open)
-- [`uv_buf_init`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_buf_init)
-- [`uv_fs_read`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_read)
-- [`uv_fs_close`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_close)
+- [`uv_fs_open`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_open)
+- [`uv_buf_init`](http://docs.libuv.org/en/latest/misc.html#c.uv_buf_init)
+- [`uv_fs_read`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_read)
+- [`uv_fs_close`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_close)
 
 ## Hints
 

--- a/exercises/04_fs_readasync/problem.md
+++ b/exercises/04_fs_readasync/problem.md
@@ -12,9 +12,9 @@ These are almost identical to the previous exercise and thus should be easy to a
 
 ## Resources
 
-- [`uv_fs_open`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_open)
-- [`uv_buf_init`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_buf_init)
-- [`uv_fs_read`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_read)
-- [`uv_fs_close`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_close)
-- [`uv_read_cb`](https://github.com/thlorenz/libuv-dox/blob/master/callbacks.md#uv_read_cb)
-- [`uv_fs_req_cleanup`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_req_cleanup)
+- [`uv_fs_open`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_open)
+- [`uv_buf_init`](http://docs.libuv.org/en/latest/misc.html#c.uv_buf_init)
+- [`uv_fs_read`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_read)
+- [`uv_fs_close`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_close)
+- [`uv_read_cb`](http://docs.libuv.org/en/latest/stream.html#c.uv_read_cb)
+- [`uv_fs_req_cleanup`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_req_cleanup)

--- a/exercises/05_fs_readasync_context/problem.md
+++ b/exercises/05_fs_readasync_context/problem.md
@@ -38,9 +38,9 @@ a common technique used in libraries using libuv and even in libuv itself.
 
 ## Resources
 
-- [`uv_fs_open`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_open)
-- [`uv_buf_init`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_buf_init)
-- [`uv_fs_read`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_read)
-- [`uv_fs_close`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_close)
-- [`uv_read_cb`](https://github.com/thlorenz/libuv-dox/blob/master/callbacks.md#uv_read_cb)
-- [`uv_fs_req_cleanup`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_req_cleanup)
+- [`uv_fs_open`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_open)
+- [`uv_buf_init`](http://docs.libuv.org/en/latest/misc.html#c.uv_buf_init)
+- [`uv_fs_read`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_read)
+- [`uv_fs_close`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_close)
+- [`uv_read_cb`](http://docs.libuv.org/en/latest/stream.html#c.uv_read_cb)
+- [`uv_fs_req_cleanup`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_req_cleanup)

--- a/exercises/06_fs_allasync/problem.md
+++ b/exercises/06_fs_allasync/problem.md
@@ -49,9 +49,9 @@ works since the buffer we are reading is very small but may not be true when rea
 
 ## Resources
 
-- [`uv_fs_open`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_open)
-- [`uv_buf_init`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_buf_init)
-- [`uv_fs_read`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_read)
-- [`uv_fs_close`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_close)
-- [`uv_read_cb`](https://github.com/thlorenz/libuv-dox/blob/master/callbacks.md#uv_read_cb)
-- [`uv_fs_req_cleanup`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_fs_req_cleanup)
+- [`uv_fs_open`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_open)
+- [`uv_buf_init`](http://docs.libuv.org/en/latest/misc.html#c.uv_buf_init)
+- [`uv_fs_read`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_read)
+- [`uv_fs_close`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_close)
+- [`uv_read_cb`](http://docs.libuv.org/en/latest/stream.html#c.uv_read_cb)
+- [`uv_fs_req_cleanup`](http://docs.libuv.org/en/latest/fs.html#c.uv_fs_req_cleanup)

--- a/exercises/07_tcp_echo_server/problem.md
+++ b/exercises/07_tcp_echo_server/problem.md
@@ -14,17 +14,17 @@ So lets start with the easy part.
 ### Starting the Server and Listening on a Port
 
 First of all we need to initialize our server `tcp_server`. 
-This is done via [`uv_tcp_init`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_tcp_init).
+This is done via [`uv_tcp_init`](http://docs.libuv.org/en/latest/tcp.html#c.uv_tcp_init).
 Our server represents the TCP `handle`.
 
 Next we need to obtain a socket address for the given host and port and then bind it to our server.
 You should have a look at the following to methods provided by libuv:
 
-- [`uv_ip4_addr`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_ip4_addr)
-- [`uv_tcp_bind`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_tcp_bind)
+- [`uv_ip4_addr`](http://docs.libuv.org/en/latest/misc.html#c.uv_ip4_addr)
+- [`uv_tcp_bind`](http://docs.libuv.org/en/latest/tcp.html#c.uv_tcp_bind)
 
 Finally we listen for connections via
-[`uv_listen`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_listen).
+[`uv_listen`](http://docs.libuv.org/en/latest/stream.html#c.uv_listen).
 
 ### C Inheritance Technique
 
@@ -34,9 +34,9 @@ This works because `uv_tcp_t` inherits `uv_stream_t` via a technique explained i
 
 You should make sure you review how this works by investigating the following:
 
-- [`uv_tcp_t`](https://github.com/thlorenz/libuv-dox/blob/master/types.md#uv_tcp_t--uv_stream_t)
-- [`uv_stream_t`](https://github.com/thlorenz/libuv-dox/blob/master/types.md#streams)
-- [`uv_handle_t`](https://github.com/thlorenz/libuv-dox/blob/master/types.md#uv_handle_t)
+- [`uv_tcp_t`](http://docs.libuv.org/en/latest/tcp.html)
+- [`uv_stream_t`](http://docs.libuv.org/en/latest/stream.html)
+- [`uv_handle_t`](http://docs.libuv.org/en/latest/handle.html)
 
 We are using this technique in our code as well to wrap the `uv_write_req` in order to add the `buf` field:
 
@@ -64,10 +64,10 @@ On windows you may have to use telnet or putty.
 
 ## Resources (not yet mentioned)
 
-- [`uv_tcp_init`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_tcp_init)
-- [`uv_accept`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_accept)
-- [`uv_read_start`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_read_start)
-- [`uv_close`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_close)
+- [`uv_tcp_init`](http://docs.libuv.org/en/latest/tcp.html#c.uv_tcp_init)
+- [`uv_accept`](http://docs.libuv.org/en/latest/stream.html#c.uv_accept)
+- [`uv_read_start`](http://docs.libuv.org/en/latest/stream.html#c.uv_read_start)
+- [`uv_close`](http://docs.libuv.org/en/latest/handle.html#c.uv_close)
 
 ## Verification
 

--- a/exercises/08_horse_race/problem.md
+++ b/exercises/08_horse_race/problem.md
@@ -23,8 +23,8 @@ Whenever we add a horse we create an async worker, initialize it and put it on t
 
 **Part of your task** is to complete these steps and I'd suggest looking at the following:
 
-- [`uv_async_init`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_async_init)
-- [`uv_queue_work`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_queue_work)
+- [`uv_async_init`](http://docs.libuv.org/en/latest/async.html#c.uv_async_init)
+- [`uv_queue_work`](http://docs.libuv.org/en/latest/threadpool.html#c.uv_queue_work)
 
 Note that the `race_cb` ("do work"), `finish_cb` and `progress_cb` have already been implemented for you.
 
@@ -40,7 +40,7 @@ Drawing the horses from different threads results in flickering, funky symbols a
 The solution is to draw all horses on the main thread.
 
 But how do we tell the main thread to draw the horse in a different location if it moved?
-Have a look at [`uv_async_send`](https://github.com/thlorenz/libuv-dox/blob/master/methods.md#uv_async_send).
+Have a look at [`uv_async_send`](http://docs.libuv.org/en/latest/async.html#c.uv_async_send).
 This method allows us to report progress. It ends up invoking our `progress_cb` on the **main thread**, passing along
 our `async` worker. As before we use its the `data` field to pass along the context we need.
 

--- a/workshopper/help.txt
+++ b/workshopper/help.txt
@@ -5,10 +5,11 @@
     - http://www.learn-c.org/
     - or this book: http://www.amazon.com/dp/0131103628/ 
 
-  Trouble understanding libuv? Review either of the below:
+  Trouble understanding libuv? Review the below:
+    - http://docs.libuv.org/en/latest/ (official libuv documentation)
     - http://nikhilm.github.io/uvbook/ (although examples are outdated this is still an awesome resource)
-    - https://github.com/thlorenz/libuv-dox (provides docs and updated examples)
-    - https://github.com/joyent/libuv/blob/master/include/uv.h (header file which will answer all your questions if you're patient)
+    - https://github.com/thlorenz/libuv-dox/tree/master/examples (libuv examples)
+    - https://github.com/libuv/libuv/blob/v1.x/include/uv.h (header file which will answer all your questions if you're patient)
 
   If you're looking for general help with libuv and like to chat?
     - the #libuv channel on Freenode IRC is usually a great place to find someone willing to help


### PR DESCRIPTION
This patch replaces the old reference links with ones
from docs.libuv.org/en/latest