### PR TITLE
Fix: Null terminate buffer in 03_fs_readsync

### DIFF
--- a/exercises/03_fs_readsync/solution.c
+++ b/exercises/03_fs_readsync/solution.c
@@ -13,8 +13,11 @@ int main() {
   if (r < 0) CHECK(r, "uv_fs_open");
 
   /* 2. Create buffer and initialize it to turn it into a a uv_buf_t which adds length field */
-  char buf[BUF_SIZE];
-  uv_buf_t iov = uv_buf_init(buf, sizeof(buf));
+  /*    The + 1 is for the string null terminator, because log_report and log_info need it */
+  /*    Make sure you set your uv_buf_t size to BUF_SIZE instead of sizeof(buf) */
+  char buf[BUF_SIZE + 1];
+  memset(buf, 0, sizeof(buf));
+  uv_buf_t iov = uv_buf_init(buf, BUF_SIZE);
 
   /* 3. Use the file descriptor (the .result of the open_req) to read from the file into the buffer */
   uv_fs_t read_req;

--- a/src/03_fs_readsync.c
+++ b/src/03_fs_readsync.c
@@ -13,7 +13,10 @@ int main() {
   if (r < 0) CHECK(r, "uv_fs_open");
 
   /* 2. Create buffer and initialize it to turn it into a a uv_buf_t which adds length field */
-  char buf[BUF_SIZE];
+  /*    The + 1 is for the string null terminator, because log_report and log_info need it */
+  /*    Make sure you set your uv_buf_t size to BUF_SIZE instead of sizeof(buf) */
+  char buf[BUF_SIZE + 1];
+  memset(buf, 0, sizeof(buf));
 
   /* 3. Use the file descriptor (the .result of the open_req) to read from the file into the buffer */
   uv_fs_t read_req;


### PR DESCRIPTION
log_report() and log_info() expect a null terminator,
which is not provided by the current code.  This code
adds that null terminator.

This fixes the following learnuv issue:
https://github.com/thlorenz/learnuv/issues/13