### PR TITLE
deps: update gyp repository location

### DIFF
--- a/scripts/install-dependencies.py
+++ b/scripts/install-dependencies.py
@@ -32,7 +32,7 @@ run('git clone --depth 1 --branch v1.0.0-rc1 https://github.com/libuv/libuv ' + 
 
 # gyp
 mkdirp(build_dir)
-run('git clone https://git.chromium.org/external/gyp.git ' + gyp_dir)
+run('git clone https://chromium.googlesource.com/external/gyp ' + gyp_dir)
 
 # log.h
 run ('git clone --depth 1 https://github.com/thlorenz/log.h ' + logh_dir) 


### PR DESCRIPTION
The current gyp repository location is [no longer valid](https://git.chromium.org/gitweb/?p=external/gyp.git;a=commit;h=dd5618b7151fcf298a5ace284dcab6605d2fb203) and will only result in a stub project upon request.

```shell
> learnuv@0.1.2 ninja /home/paulfryzel/Workspace/learnuv
> ./gyp_learnuv.py -f ninja && ninja -C out/Debug $CURRENT_TARGET

You need to install gyp in build/gyp first. See the README.
```

This change updates that reference to the location suggested in their readme, fixing the gyp dep.

```shell
> learnuv@0.1.2 ninja /home/paulfryzel/Workspace/learnuv
> ./gyp_learnuv.py -f ninja && ninja -C out/Debug $CURRENT_TARGET

...
[2/2] LINK 01_system_info
```