### PR TITLE
fix the "implicit declaration of function ‘usleep’" issue on ubuntu 14.04

### DIFF
--- a/src/08_horse_race.c
+++ b/src/08_horse_race.c
@@ -1,3 +1,4 @@
+#define _BSD_SOURCE
 
 #include "learnuv.h"
 #include <ncurses.h>


### PR DESCRIPTION
warning: implicit declaration of function ‘usleep’ [-Wimplicit-function-declaration]
     usleep(1E6/speed);
          ^