### PR TITLE
Fix install-dependencies.py

### DIFF
--- a/scripts/install-dependencies.py
+++ b/scripts/install-dependencies.py
@@ -13,7 +13,7 @@ home        = os.path.expanduser('~')
 dot_learnuv = os.path.join(home, '.learnuv')
 
 def log_info(msg):
-    print '\033[0;32mlearnuv\033[0m ' + msg
+    print('\033[0;32mlearnuv\033[0m ' + msg)
 
 def mkdirp(dir):
     try:


### PR DESCRIPTION
`npm install` does not fork on python >3.1
```File "scripts/install-dependencies.py", line 16
    print '\033[0;32mlearnuv\033[0m ' + msg```