### PR TITLE
Update gyp_learnuv.py ( crash on compiler_version() )

### DIFF
--- a/gyp_learnuv.py
+++ b/gyp_learnuv.py
@@ -47,6 +47,10 @@ def compiler_version():
   version = proc.communicate()[0].split('.')
   version = map(int, version[:2])
   version = tuple(version)
+  try:
+    version[1]
+  except IndexError:
+    version = (version[0], 0)
   return (version, is_clang)
 
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "./gyp_learnuv.py", line 97, in <module>
    (major, minor), is_clang = compiler_version()
ValueError: need more than 1 value to unpack

Avoid crash in case the return value is only a major number, like "7" and not "7.0"