### PR TITLE
Fix "cc -dumpversion" error

### DIFF
--- a/gyp_learnuv.py
+++ b/gyp_learnuv.py
@@ -46,6 +46,8 @@ def compiler_version():
   proc = subprocess.Popen(CC.split() + ['-dumpversion'], stdout=subprocess.PIPE)
   version = proc.communicate()[0].split('.')
   version = map(int, version[:2])
+  if len(version) == 1:
+    version.append(0)
   version = tuple(version)
   return (version, is_clang)
 


### PR DESCRIPTION
On some systems `cc -dumpversion` returns only the major version. There should be a check against that.
```
  File "./gyp_learnuv.py", line 94, in <module>
    (major, minor), is_clang = compiler_version()
ValueError: need more than 1 value to unpack
```